### PR TITLE
Fixes issue on OSX where the icu4c library is incorrectly linked to the version installed with therubyracer

### DIFF
--- a/ext/edn_turbo/extconf.rb
+++ b/ext/edn_turbo/extconf.rb
@@ -9,8 +9,8 @@ header_dirs = [
 ].freeze
 
 lib_dirs = [
-  '/usr/local/lib', # must be the first entry; add others after it
-  '/usr/local/opt/icu4c/lib'
+  '/usr/local/opt/icu4c/lib',
+  '/usr/local/lib'
 ].freeze
 
 dir_config('icuuc', header_dirs, lib_dirs)


### PR DESCRIPTION
Fixes issue on OSX where the icu4c library is incorrectly linked to therubyracers v8 if that gem has been installed previously.