### PR TITLE
Upgrade rake dependency to allow rake v13

### DIFF
--- a/edn_turbo.gemspec
+++ b/edn_turbo.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = '1.6.2'
 
   s.add_runtime_dependency('edn', '~> 1.1')
-  s.add_runtime_dependency('rake', '~> 12.3')
+  s.add_runtime_dependency('rake', '>= 12.3', '< 14.0')
   s.add_runtime_dependency('rake-compiler', '~> 1.0')
 
   s.add_development_dependency('pry-byebug', '3.7', '~> 3.7.0')


### PR DESCRIPTION
I had another gem that required rake v13, but edn_turbo requires v12, so I updated the gem spec to allow version 13.

The specs pass and the rake compile/ragel tasks all complete correctly.

I was wondering, is rake/rake-compiler even a runtime dependency of edn_ruby?

Thanks for your work on edn_turbo.