### PR TITLE
Remove extra argument to EDNT::Parser#next

### DIFF
--- a/ext/edn_turbo/main.cc
+++ b/ext/edn_turbo/main.cc
@@ -167,7 +167,7 @@ namespace edn {
 
    //
    // gets the next token in the current stream
-   static VALUE next(VALUE self, VALUE data)
+   static VALUE next(VALUE self)
    {
       return get_parser(self)->next();
    }


### PR DESCRIPTION
I'm a CEXT newbie, but this extra argument was breaking edn_turbo on truffleruby. It's declared as taking 0 arguments, but the C function takes 1.