### PR TITLE
Fix endless loop on aarch64 linux reading a IO object with fgetc

### DIFF
--- a/ext/edn_turbo/parser_def.cc
+++ b/ext/edn_turbo/parser_def.cc
@@ -128,14 +128,14 @@ namespace edn
       // read as much data available
       if (core_io) {
          // ruby core IO types
-         char c;
+         int c;
          while (1)
          {
             c = fgetc(core_io);
             if (c == EOF) {
                break;
             }
-            str_buf += c;
+            str_buf += static_cast<char>(c);
          }
 
       } else if (read_io != Qnil) {


### PR DESCRIPTION
I ran into a problem on aarch64 linux where assigning the result of `fgetc` to a `char` never resulted in a value which was equal to `EOF`. I'm guessing this is because `char` is an unsigned value and `EOF` is a signed one (-1 in this case). Assigning the result of `fgetc` to a `char` resulted in a signed value of `255` which isn't equal to `-1`.

I'm not sure why this works on Intel linux and on ARM MacOS, but installing this gem on an arm linux system results in the system memory being used up by this buffer.