### PR TITLE
properly register global Ruby VALUEs with GC

### DIFF
--- a/ext/edn_turbo/main.cc
+++ b/ext/edn_turbo/main.cc
@@ -26,6 +26,7 @@
 #include <cstring>
 
 #include <ruby/ruby.h>
+#include <ruby/internal/gc.h>
 #include <ruby/version.h>
 #include <ruby/io.h>
 
@@ -196,6 +197,13 @@ void Init_edn_turbo(void)
    if (!setlocale( LC_ALL, "" )) {
       rb_raise(rb_eRuntimeError, "Extension init error calling setlocale() - It appears your system's locale is not configured correctly.\n");
    }
+
+   // Register global VALUE slots before assigning Ruby objects to them.
+   rb_global_variable(&edn::rb_mEDN);
+   rb_global_variable(&edn::rb_mEDNT);
+   rb_global_variable(&edn::RUBY_NAN_CONST);
+   rb_global_variable(&edn::RUBY_INF_CONST);
+   rb_global_variable(&edn::EDN_EOF_CONST);
 
    edn::rb_mEDN  = rb_const_get(rb_cObject, rb_intern("EDN"));
    edn::rb_mEDNT = rb_define_module("EDNT");

--- a/spec/edn_turbo/edn_parser_spec.rb
+++ b/spec/edn_turbo/edn_parser_spec.rb
@@ -308,6 +308,17 @@ module EDNT
       it 'uuid' do
         expect(subject.parse('  #uuid "f81d4fae-7dec-11d0-a765-00a0c91e6bf6" ')).to eq('f81d4fae-7dec-11d0-a765-00a0c91e6bf6')
       end
+
+      it 'survives GC.compact while parsing tags' do
+        skip 'GC.compact not supported' unless GC.respond_to?(:compact)
+
+        data = '  #uuid "f81d4fae-7dec-11d0-a765-00a0c91e6bf6" '
+        expect(subject.parse(data)).to eq('f81d4fae-7dec-11d0-a765-00a0c91e6bf6')
+
+        GC.compact
+
+        expect(subject.parse(data)).to eq('f81d4fae-7dec-11d0-a765-00a0c91e6bf6')
+      end
     end
 
     context 'collections' do


### PR DESCRIPTION
This prevents our global VALUEs from being GC'd and causing issues

I'm on Ruby 4.0.1 on Linux. I tried Ruby 4.0.0 and saw this there too

I was having an issue of parsing EDN with tags (e.g. "#tag {}") sometimes, but not others. It would work in IRB but fail in production, even parsing simple examples.

I was getting the exception:

```
undefined method 'tagged_element' for an instance of String
               /usr/local/bundle/ruby/4.0.0/gems/edn2023-1.1.4/lib/edn/reader.rb:9:in 'EDNT
               /usr/local/bundle/ruby/4.0.0/gems/edn2023-1.1.4/lib/edn/reader.rb:9:in 'EDN
                      /usr/local/bundle/ruby/4.0.0/gems/edn2023-1.1.4/lib/edn.rb:16:in 'EDN.read'
```

Which is odd since `edn_turbo` calls `tagged_element` on the `EDN` module.

After doing some digging, I found that registering the global variables the gem uses with `rb_global_variable` did the trick and we don't see this issue anymore.

I couldn't get the rspec spec to actually fail with the currently published gem, but it fails very often on my system with IRB. Sometimes I had to run the command `require "edn_turbo"; GC.compact; EDN.read("#tag {}")` multiple times, or restart IRB and do it again, but it would eventually crash, and with this patch I could not get it to crash.

```
~ ❯ gem install edn_turbo
Fetching edn_turbo-0.8.1.gem
Building native extensions. This could take a while...
Successfully installed edn_turbo-0.8.1
Parsing documentation for edn_turbo-0.8.1
Installing ri documentation for edn_turbo-0.8.1
Done installing documentation for edn_turbo after 0 seconds
1 gem installed

~ ❯ irb
irb(main):001> require "edn_turbo"; GC.compact; EDN.read("#tag {}")
/home/caleb/.local/share/mise/installs/ruby/4.0.1/lib/ruby/gems/4.0.0/gems/edn2023-1.1.4/lib/edn/reader.rb:9: [BUG] Segmentation fault at 0x0000000000000000
ruby 4.0.1 (2026-01-13 revision e04267a14b) +PRISM [x86_64-linux]

...
```

See the full error here: https://gist.github.com/caleb/4c1c6bc41c75e5a3494b88040123f29b