### PR TITLE
bump min ruby version to 3.0

### DIFF
--- a/.github/workflows/ruby-ext.yml
+++ b/.github/workflows/ruby-ext.yml
@@ -15,13 +15,12 @@ jobs:
         #  - macos-latest
         # Due to https://github.com/actions/runner/issues/849, we have to use quotes for '3.0'
         ruby:
-          - '2.6'
-          - '2.7'
           - '3.0'
           - '3.1'
           - '3.2'
           - '3.3'
           - '3.4'
+          - '4.0'
     runs-on: ${{ matrix.os }}
     steps:
     - run: sudo apt-get install -y libicu-dev libreadline-dev ragel
@@ -29,7 +28,7 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby }}
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - run: bundle install
     - run: bundle exec rake
     - run: bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. This change
 ### Added
 
 ### Changed
+* Bumped minimum ruby version to 3.0.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ irb(main):008:0> Benchmark.realtime { 100000.times { EDN::read(s) } }
 Dependencies
 ============
 
-Ruby 2.6 or greater.
+Ruby 3.0 or greater.
 
 - ruby gems:
   - [rake](http://rake.rubyforge.org)

--- a/edn_turbo.gemspec
+++ b/edn_turbo.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |s|
   s.version            = EDNT::VERSION
   s.platform           = Gem::Platform::RUBY
 
-  s.required_ruby_version = '>= 2.6.0'
+  s.required_ruby_version = '>= 3.0.0'
 
   s.required_rubygems_version = Gem::Requirement.new('>= 0') if
     s.respond_to? :required_rubygems_version=


### PR DESCRIPTION
@Caleb Hi, I'm bumping the minimum ruby to 3.x as I imagine few people are sticking on 2.x and it looks like your PR requires headers not present in ruby < 3. Sound OK?

I've also updated the actions to remove 2.x and add 4.0 for running the tests.